### PR TITLE
Groups: moyenne et upvotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Notre API va permettre à des sites web d'enregistrer des avis sur leurs produits. Ces avis auront eux même un système de vote ("upvote") qui permettront de donner un aperçu de la pertinence de la note.
 
-## Dépendances utilisés
+## Dépendances notables
 
 - Doctrine
 - Api Platform
-- 
+- Validator
 
 ## Lancer le projet
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# 🥧 G-RATIN -- API de Notes et de système de vote
+
+Notre API va permettre à des sites web d'enregistrer des avis sur leurs produits. Ces avis auront eux même un système de vote ("upvote") qui permettront de donner un aperçu de la pertinence de la note.
+
+## Dépendances utilisés
+
+- Doctrine
+- Api Platform
+- 
+
+## Lancer le projet
+
+Premièrement, il vous faudra lancer la commande `composer install` à la racine du projet pour installer les dépendances citées au-dessus. 
+Ensuite pour démarrer le projet on va lancer la commande `symfony server:start`.
+
+On va ensuite mettre en place la BDD avec les fixtures, pour se faire commencez par lancer la commande `php bin/console doctrine:schema:validate` à la racine du projet puis la commande `php bin/console doctrine:schema:update --force`. Cela va permettre de créer une BDD avec le bon modèle, celle-ci est retrouvable dans `var/data.db`.
+
+Pour remplir la BDD des fixtures, lancer la commande `php bin/console hautelook:fixtures:load`.
+
+Une fois le projet lancé et la BDD mise en place, vous pouvez accéder aux différentes routes questionnables sur l'api à l'adresse suivante [localhost:8000/api](localhost:8000/api).
+
+Pour faire vos tests sur l'API, vous allez pouvoir avoir besoin d'un token valide. Pour récupérer celui-ci, rendez-vous dans la BDD dans la table website pour récupérer l'url d'une des fixture, puis interroger l'api sur la route custom get_token de la sorte :
+```
+http://localhost:8000/api/get_token?website_url={url}
+```
+
+

--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ Pour remplir la BDD des fixtures, lancer la commande `php bin/console hautelook:
 
 Une fois le projet lancé et la BDD mise en place, vous pouvez accéder aux différentes routes questionnables sur l'api à l'adresse suivante [localhost:8000/api](localhost:8000/api).
 
-Pour faire vos tests sur l'API, vous allez pouvoir avoir besoin d'un token valide. Pour récupérer celui-ci, rendez-vous dans la BDD dans la table website pour récupérer l'url d'une des fixture, puis interroger l'api sur la route custom get_token de la sorte :
+Pour faire vos tests sur l'API, vous allez pouvoir avoir besoin d'un token valide. Pour récupérer celui-ci, choisissez un url (comme par exemple www.toto.fr), puis interroger l'api sur la route custom get_token de la sorte :
 ```
 http://localhost:8000/api/get_token?website_url={url}
 ```
+
+// TODO
+
+
 
 

--- a/fixtures/websites.yaml
+++ b/fixtures/websites.yaml
@@ -1,4 +1,4 @@
 App\Entity\Website:
   website_{1..3}:
     domain: <url()>
-    token: <asciify()>
+    token: <uuid()>

--- a/src/Context/WebsiteContext.php
+++ b/src/Context/WebsiteContext.php
@@ -22,10 +22,11 @@ class WebsiteContext {
             if (empty($apiKey)) {
                 throw new BadRequestException('The API Key must be specified');
             }
-            $this->_website = $this->websiteRepository->findOneBy(['token' => $apiKey]);
-            if (empty($this->_website)) {
+            $website = $this->websiteRepository->findOneBy(['token' => $apiKey]);
+            if (empty($website)) {
                 throw new BadRequestException('The API Key is not valid');
             }
+            $this->_website = $website;
         }
         return $this->_website;
     }

--- a/src/Entity/Rating.php
+++ b/src/Entity/Rating.php
@@ -53,6 +53,7 @@ class Rating implements WebsiteAwareInterface
         $this->votes = new ArrayCollection();
     }
 
+    #[Groups("rating")]
     public function getId(): ?int
     {
         return $this->id;

--- a/src/Entity/Rating.php
+++ b/src/Entity/Rating.php
@@ -12,13 +12,16 @@ use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ApiResource(
     collectionOperations: [
-        "get",
+        "get" => [],
         "post" => [ "security_post_denormalize" => "is_granted('READ_WA_ITEM', object)" ]
     ],
     itemOperations: [
         "get" => [ "security" => "is_granted('READ_WA_ITEM', object)" ],
         "put" => [ "security" => "is_granted('READ_WA_ITEM', object)" ],
         "delete" => [ "security" => "is_granted('READ_WA_ITEM', object)" ],
+    ],
+    normalizationContext: [
+        "groups" => ['rating']
     ]
 )]
 #[ORM\Entity(repositoryClass: RatingRepository::class)]
@@ -55,6 +58,7 @@ class Rating implements WebsiteAwareInterface
         return $this->id;
     }
 
+    #[Groups("rating")]
     public function getMark(): ?float
     {
         return $this->mark;
@@ -67,6 +71,7 @@ class Rating implements WebsiteAwareInterface
         return $this;
     }
 
+    #[Groups("rating")]
     public function getAuthorUserEmail(): ?string
     {
         return $this->authorUserEmail;
@@ -79,6 +84,7 @@ class Rating implements WebsiteAwareInterface
         return $this;
     }
 
+    #[Groups("rating")]
     public function getProduct(): ?Product
     {
         return $this->product;
@@ -91,6 +97,7 @@ class Rating implements WebsiteAwareInterface
         return $this;
     }
 
+    #[Groups("rating")]
     public function getMetadata(): ?array
     {
         return $this->metadata;
@@ -106,6 +113,7 @@ class Rating implements WebsiteAwareInterface
     /**
      * @return Collection|Vote[]
      */
+    #[Groups("rating")]
     public function getVotes(): Collection
     {
         return $this->votes;
@@ -137,9 +145,16 @@ class Rating implements WebsiteAwareInterface
         return $this->getProduct()->getWebsite();
     }
 
-    #[Groups("rating:collection:get")] // <- MAGIC IS HERE, you can set a group on a method.
-    public function getAverage(): int
+    #[Groups("rating")]
+    public function getUpVoteScore(): int
     {
-        return 5;
+        $votes = $this->getVotes()->toArray();
+        return array_reduce($votes, function($val, $vote) {
+            /** @var Vote $vote */
+            if ($vote->getIsUp()) {
+                return $val + 1;
+            }
+            return $val - 1;
+        }, 0);
     }
 }

--- a/src/Entity/Vote.php
+++ b/src/Entity/Vote.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 use ApiPlatform\Core\Annotation\ApiResource;
 use App\Repository\VoteRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ApiResource(
     collectionOperations: [
@@ -15,6 +16,9 @@ use Doctrine\ORM\Mapping as ORM;
         "get" => [ "security" => "is_granted('READ_WA_ITEM', object)" ],
         "put" => [ "security" => "is_granted('READ_WA_ITEM', object)" ],
         "delete" => [ "security" => "is_granted('READ_WA_ITEM', object)" ],
+    ],
+    normalizationContext: [
+        "groups" => ['vote']
     ]
 )]
 #[ORM\Entity(repositoryClass: VoteRepository::class)]
@@ -38,11 +42,13 @@ class Vote implements WebsiteAwareInterface
     #[ORM\Column(type: 'json', nullable: true)]
     private $metadata = [];
 
+    #[Groups("vote")]
     public function getId(): ?int
     {
         return $this->id;
     }
 
+    #[Groups("vote")]
     public function getIsUp(): ?bool
     {
         return $this->isUp;
@@ -55,6 +61,7 @@ class Vote implements WebsiteAwareInterface
         return $this;
     }
 
+    #[Groups("vote")]
     public function getAuthorUserEmail(): ?string
     {
         return $this->authorUserEmail;
@@ -67,6 +74,7 @@ class Vote implements WebsiteAwareInterface
         return $this;
     }
 
+    #[Groups("vote")]
     public function getRating(): ?Rating
     {
         return $this->rating;
@@ -79,6 +87,7 @@ class Vote implements WebsiteAwareInterface
         return $this;
     }
 
+    #[Groups("vote")]
     public function getMetadata(): ?array
     {
         return $this->metadata;


### PR DESCRIPTION
Ajoute les groupes de ApiPlatform pour calculer la moyenne et le upvote des produits et notes (des champs calculés)

Un produit:
```json
{
	"@id": "\/api\/products\/1",
	"@type": "Product",
	"id": 1,
	"reference": "0001",
	"ratings": [],
	"averageMark": 0 // <--- ICI
}
```

Une notation:
```json
{
	"@id": "\/api\/ratings\/4",
	"@type": "Rating",
	"id": 4,
	"mark": 4,
	"authorUserEmail": "ghjg@ghjg.fr",
	"product": "\/api\/products\/8",
	"metadata": [],
	"votes": [
		"\/api\/votes\/1",
		"\/api\/votes\/3",
		"\/api\/votes\/4"
	],
	"upVoteScore": 1 //<-- ICI
},
```